### PR TITLE
disable upload of runtime config

### DIFF
--- a/operations/disable-runtime-config-upload.yml
+++ b/operations/disable-runtime-config-upload.yml
@@ -1,0 +1,5 @@
+- type: remove
+  path: /jobs/name=update-cloud-and-runtime-config-((bosh_lite_name))/plan/1/aggregate/task=Update runtime-config
+
+- type: remove
+  path: /jobs/name=update-cloud-and-runtime-config-((bosh_lite_name))/plan/put=state


### PR DESCRIPTION
older versions of cf-deployment did not use runtime config. In order to
make 1-click pipeline useable for these older versions, simply remove
the upload task for runtime config.

Note: had also to remove putting back the state after the upload, as the
task will fail without the output of upload-runtime config.