### PR TITLE
make it possible to use "bosh-lite-state" from other directories

### DIFF
--- a/tasks/set-env-template
+++ b/tasks/set-env-template
@@ -1,8 +1,14 @@
+#!/bin/bash
+
+# set -x
 BOSHLITE_HOSTNAME=$BOSH_LITE_NAME.$DOMAIN_NAME
+
+export BOSH_LITE_STATE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 
 function exit_with_error_message() {
   echo "Error - /etc/hosts is missing the following entry:"
-  echo "$(cat ip) ${BOSHLITE_HOSTNAME}"
+  echo "$(cat ${BOSH_LITE_STATE_DIR}/ip) ${BOSHLITE_HOSTNAME}"
   exit 1
 }
 
@@ -11,7 +17,7 @@ HOST_FOUND=$?
 if [ $HOST_FOUND -ne 0 ]; then
   exit_with_error_message
 else
-  grep ${BOSHLITE_HOSTNAME} /etc/hosts | grep --quiet $(cat ip)
+  grep ${BOSHLITE_HOSTNAME} /etc/hosts | grep --quiet $(cat ${BOSH_LITE_STATE_DIR}/ip)
   CORRECT_IP=$?
   if [ $CORRECT_IP -ne 0 ]; then
     exit_with_error_message
@@ -24,13 +30,13 @@ export BOSH_CA_CERT="$CA_CERT"
 export BOSH_CLIENT=admin
 export BOSH_CLIENT_SECRET="$CLIENT_SECRET"
 
-chmod 600 jumpbox.key
+chmod 600 ${BOSH_LITE_STATE_DIR}/jumpbox.key
 
 mkdir -p ~/.ssh
 touch ~/.ssh/known_hosts
 
 ssh-keygen -q -R "${BOSHLITE_HOSTNAME}" > /dev/null
-ssh-keygen -q -R $(cat ip) > /dev/null
+ssh-keygen -q -R $(cat ${BOSH_LITE_STATE_DIR}/ip) > /dev/null
 ssh-keyscan -H "${BOSHLITE_HOSTNAME}" >> ~/.ssh/known_hosts 2> /dev/null
 
-export BOSH_ALL_PROXY=ssh+socks5://jumpbox@${BOSHLITE_HOSTNAME}:22?private-key=jumpbox.key
+export BOSH_ALL_PROXY=ssh+socks5://jumpbox@${BOSHLITE_HOSTNAME}:22?private-key=${BOSH_LITE_STATE_DIR}/jumpbox.key


### PR DESCRIPTION
1-click pipelines provides some awesome ease of use tools in the state repository it manages with `.envrc` scripts to setup the environment to be able to directly talk to the bosh director without further "adoo". 

However sometimes its nice to use the 1-click-pipeline managed bosh-lite in the cloud outside of the bosh-lite state repository, e.g. inside a release directory, to run scripts and use operations files. Therefore we have enhanced the "set-env.sh" shell script so it can be sourced from a release dir.

We basicly changed two things:
- make set-env.sh sourceable from another directory
- provide an exported variable `BOSH_LITE_STATE_DIR` which can be used in other scripts to access the ip / jumpbox key, cf-vars and other stuff.

With the new set-env.sh our workflow looks like this:
```
cd workspace/my-release
source ~/workspace/bosh-lite-state/environments/softlayer/director/<my-bosh-lite>/set-env.sh
./scripts/create-upload-deploy-release.sh -o ./operations/some-ops.yml 
```